### PR TITLE
Refactor.

### DIFF
--- a/src/wp-admin/admin-ajax.php
+++ b/src/wp-admin/admin-ajax.php
@@ -169,6 +169,9 @@ add_action( 'wp_ajax_nopriv_generate-password', 'wp_ajax_nopriv_generate_passwor
 
 add_action( 'wp_ajax_nopriv_heartbeat', 'wp_ajax_nopriv_heartbeat', 1 );
 
+// Register Plugin Dependencies Ajax calls.
+add_action( 'wp_ajax_check_plugin_dependencies', array( 'WP_Plugin_Dependencies', 'check_plugin_dependencies_during_ajax' ) );
+
 $action = $_REQUEST['action'];
 
 if ( is_user_logged_in() ) {

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -584,7 +584,7 @@ th.sorted.desc:hover .sorting-indicator.asc:before {
 	z-index: 1;
 }
 
-.check-column .label-covers-full-cell:hover + input {
+.check-column .label-covers-full-cell:hover + input:not(:disabled) {
 	box-shadow: 0 0 0 1px #2271b1;
 }
 
@@ -1613,8 +1613,11 @@ div.action-links,
 }
 
 .plugin-card .plugin-dependency .more-details-link {
-	flex-basis: 25%;
-	text-align: right;
+	margin-left: auto;
+}
+
+.rtl .plugin-card .plugin-dependency .more-details-link {
+	margin-right: auto;
 }
 
 @media (max-width: 939px) {
@@ -1622,7 +1625,6 @@ div.action-links,
 		flex-basis: 69%;
 	}
 	.plugin-card .plugin-dependency .more-details-link {
-		flex-basis: 30%;
 	}
 }
 

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -518,6 +518,8 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 			// Remove any HTML from the description.
 			$description = strip_tags( $plugin['short_description'] );
 
+			$description .= $this->get_dependencies_notice( $plugin );
+
 			/**
 			 * Filters the plugin card description on the Add Plugins screen.
 			 *
@@ -718,5 +720,88 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 		if ( ! empty( $group ) ) {
 			echo '</div></div>';
 		}
+	}
+
+	/**
+	 * Returns a notice containing a list of dependencies required by the plugin.
+	 *
+	 * @since 6.4.0
+	 *
+	 * @param array  $plugin_data An array of plugin data. See {@see plugins_api()}
+	 *                            for the list of possible values.
+	 * @return string A notice containing a list of dependencies required by the plugin,
+	 *                or an empty string if none is required.
+	 */
+	protected function get_dependencies_notice( $plugin_data ) {
+		if ( empty( $plugin_data['requires_plugins'] ) ) {
+			return '';
+		}
+
+		$no_name_markup  = '<div class="plugin-dependency"><span class="plugin-dependency-name">%s</span></div>';
+		$has_name_markup = '<div class="plugin-dependency"><span class="plugin-dependency-name">%s</span> %s</div>';
+
+		$dependencies_list = '';
+		foreach ( $plugin_data['requires_plugins'] as $dependency ) {
+			if ( false === WP_Plugin_Dependencies::get_dependency_filepath( $dependency ) ) {
+				$dependencies_list .= sprintf( $no_name_markup, esc_html( $dependency ) );
+				continue;
+			}
+
+			$dependency_data = WP_Plugin_Dependencies::get_dependency_data( $dependency );
+
+			if ( false === $dependency_data ) {
+				$dependencies_list .= sprintf( $no_name_markup, esc_html( $dependency ) );
+				continue;
+			}
+
+			if ( empty( $dependency_data['version'] ) || empty( $dependency_data['name'] ) || empty( $dependency_data['slug'] ) ) {
+				$dependencies_list .= sprintf( $no_name_markup, esc_html( $dependency ) );
+				continue;
+			}
+
+			$more_details_link  = $this->get_more_details_link( $dependency_data['name'], $dependency_data['slug'] );
+			$dependencies_list .= sprintf( $has_name_markup, esc_html( $dependency_data['name'] ), $more_details_link );
+		}
+
+		$dependencies_notice = sprintf(
+			'<div class="plugin-dependencies"><p class="plugin-dependencies-explainer-text">%s</p> %s</div>',
+			'<strong>' . __( 'Additional plugins are required' ) . '</strong>',
+			$dependencies_list
+		);
+
+		return $dependencies_notice;
+	}
+
+	/**
+	 * Creates a 'More details' link for the plugin.
+	 *
+	 * @since 6.4.0
+	 *
+	 * @param array  $plugin_data An array of plugin data. See {@see plugins_api()}
+	 *                            for the list of possible values.
+	 * @return string The 'More details' link for the plugin.
+	 */
+	protected function get_more_details_link( $name, $slug ) {
+		$url = add_query_arg(
+			array(
+				'tab'       => 'plugin-information',
+				'plugin'    => $slug,
+				'TB_iframe' => 'true',
+				'width'     => '600',
+				'height'    => '550',
+			),
+			network_admin_url( 'plugin-install.php' )
+		);
+
+		$more_details_link = sprintf(
+			'<a href="%1$s" class="more-details-link thickbox open-plugin-details-modal" aria-label="%2$s" data-title="%3$s">%4$s</a>',
+			esc_url( $url ),
+			/* translators: %s: Plugin name. */
+			sprintf( __( 'More information about %s' ), esc_html( $name ) ),
+			esc_attr( $name ),
+			__( 'More Details' )
+		);
+
+		return $more_details_link;
 	}
 }

--- a/src/wp-admin/plugin-install.php
+++ b/src/wp-admin/plugin-install.php
@@ -134,6 +134,8 @@ get_current_screen()->set_screen_reader_content(
  * WordPress Administration Template Header.
  */
 require_once ABSPATH . 'wp-admin/admin-header.php';
+
+WP_Plugin_Dependencies::display_admin_notice_for_unmet_dependencies();
 ?>
 <div class="wrap <?php echo esc_attr( "plugin-install-tab-$tab" ); ?>">
 <h1 class="wp-heading-inline">

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -716,6 +716,8 @@ elseif ( isset( $_GET['deleted'] ) ) :
 	<div id="message" class="updated notice is-dismissible"><p><?php _e( 'Selected plugins will no longer be auto-updated.' ); ?></p></div>
 <?php endif; ?>
 
+<?php WP_Plugin_Dependencies::display_admin_notice_for_unmet_dependencies(); ?>
+
 <div class="wrap">
 <h1 class="wp-heading-inline">
 <?php

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -721,14 +721,4 @@ add_action( 'init', 'wp_create_initial_post_meta' );
 // Font management.
 add_action( 'wp_head', 'wp_print_font_faces', 50 );
 
-// Plugin Dependency hooks.
-if ( is_admin() ) {
-	add_filter( 'plugin_install_description', array( 'WP_Plugin_Dependencies', 'plugin_install_description_uninstalled' ), 10, 2 );
-	add_filter( 'plugin_install_description', array( 'WP_Plugin_Dependencies', 'add_dependencies_to_dependent_plugin_card' ), 10, 1 );
-	add_action( 'admin_init', array( 'WP_Plugin_Dependencies', 'modify_plugin_row' ), 15 );
-	add_action( 'admin_notices', array( 'WP_Plugin_Dependencies', 'display_admin_notice_for_unmet_dependencies' ) );
-	add_action( 'network_admin_notices', array( 'WP_Plugin_Dependencies', 'display_admin_notice_for_unmet_dependencies' ) );
-	add_action( 'wp_ajax_check_plugin_dependencies', array( 'WP_Plugin_Dependencies', 'check_plugin_dependencies' ) );
-}
-
 unset( $filter, $action );


### PR DESCRIPTION
- Moves plugin row methods to `class-wp-plugins-list-table.php`.
- Moves plugin card methods to `class-wp-plugin-install-list-table.php`.
- Moves the registration of the AJAX callback to `admin-ajax.php`.
- Renames various properties.
- Renames various methods.
- Improves/extends documentation for merging to WordPress Core.
- Disables the Bulk Actions checkbox in `plugins.php` for dependencies that have active dependents.
- Disables the Bulk Actions checkbox in `plugins.php` for dependents that have unmet dependencies.
- Adds a CSS fix for focus effects on a `<label>` with a disabled input.
- Adds a CSS fix for plugin card "More details" links in RTL writing mode.
- Removes escaping from translated strings.
- Replaces `wp_kses_post()` of whole strings with `esc_html()` for the parts that need to be escaped.
- Establishes a public API:
  - `::initialize()`
  - `::has_dependents( string $plugin_file )`
  - `::has_dependencies( string $plugin_file )`
  - `::has_active_dependents( string $plugin_file )`
  - `::has_unmet_dependencies( string $plugin_file )`
  - `::get_dependent_names( string $plugin_file )`
  - `::get_dependency_names( string $plugin_file )`
  - `::get_dependency_filepath( string $slug )`
  - `::get_dependency_data( string $slug )`
  - `::display_admin_notice_for_unmet_dependencies()` - `public` as it's required by Core.
  - `::check_plugin_dependencies_during_ajax()` - `public` as it's required by Core.