### PR TITLE
Updates to Plugin Dependencies

### DIFF
--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -740,8 +740,10 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 		$no_name_markup  = '<div class="plugin-dependency"><span class="plugin-dependency-name">%s</span></div>';
 		$has_name_markup = '<div class="plugin-dependency"><span class="plugin-dependency-name">%s</span> %s</div>';
 
+		$plugin_file       = WP_Plugin_Dependencies::get_dependent_filepath( $plugin_data['slug'] );
+		$dependencies      = WP_Plugin_Dependencies::get_dependencies( $plugin_file );
 		$dependencies_list = '';
-		foreach ( $plugin_data['requires_plugins'] as $dependency ) {
+		foreach ( $dependencies as $dependency ) {
 			if ( false === WP_Plugin_Dependencies::get_dependency_filepath( $dependency ) ) {
 				$dependencies_list .= sprintf( $no_name_markup, esc_html( $dependency ) );
 				continue;

--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -643,10 +643,6 @@ class WP_Plugin_Dependencies {
 
 		$dependency_filepaths = array();
 
-		if ( empty( self::$plugins ) ) {
-			return $dependency_filepaths;
-		}
-
 		$plugin_dirnames = self::get_plugin_dirnames();
 		if ( empty( $plugin_dirnames ) ) {
 			return $dependency_filepaths;

--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -291,6 +291,10 @@ class WP_Plugin_Dependencies {
 			self::get_dependency_filepaths();
 		}
 
+		if ( ! isset( self::$dependency_filepaths[ $slug ] ) ) {
+			return false;
+		}
+
 		return self::$dependency_filepaths[ $slug ];
 	}
 

--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -561,42 +561,6 @@ class WP_Plugin_Dependencies {
 	}
 
 	/**
-	 * Gets the slugs of plugins that the dependent requires.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param string $plugin_file The dependent plugin's filepath, relative to the plugins directory.
-	 * @return array An array of dependency plugin slugs.
-	 */
-	protected static function get_dependencies( $plugin_file ) {
-		if ( isset( self::$dependencies[ $plugin_file ] ) ) {
-			return self::$dependencies[ $plugin_file ];
-		}
-
-		return array();
-	}
-
-	/**
-	 * Gets filepaths of plugins that require the dependency.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @param string $slug The dependency's slug.
-	 * @return array An array of dependent plugin filepaths, relative to the plugins directory.
-	 */
-	protected static function get_dependents( $slug ) {
-		$dependents = array();
-
-		foreach ( self::$dependencies as $dependent => $dependencies ) {
-			if ( in_array( $slug, $dependencies, true ) ) {
-				$dependents[] = $dependent;
-			}
-		}
-
-		return $dependents;
-	}
-
-	/**
 	 * Gets plugin filepaths for active plugins that depend on the dependency.
 	 *
 	 * Recurses for each dependent that is also a dependency.

--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -188,6 +188,23 @@ class WP_Plugin_Dependencies {
 	}
 
 	/**
+	 * Gets a dependent plugin's filepath.
+	 *
+	 * @since 6.4.0
+	 *
+	 * @param string $slug  The dependent plugin's slug.
+	 * @return string|false The dependent plugin's filepath, relative to the plugins directory,
+	 *                      or false if the plugin has no dependencies.
+	 */
+	public static function get_dependent_filepath( $slug ) {
+		if ( ! isset( self::$dependent_slugs[ $slug ] ) ) {
+			return false;
+		}
+
+		return self::$dependent_slugs[ $slug ];
+	}
+
+	/**
 	 * Determines whether the plugin has unmet dependencies.
 	 *
 	 * @since 6.4.0

--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -173,6 +173,22 @@ class WP_Plugin_Dependencies {
 	}
 
 	/**
+	 * Gets the slugs of plugins that the dependent requires.
+	 *
+	 * @since 6.4.0
+	 *
+	 * @param string $plugin_file The dependent plugin's filepath, relative to the plugins directory.
+	 * @return array An array of dependency plugin slugs.
+	 */
+	public static function get_dependencies( $plugin_file ) {
+		if ( isset( self::$dependencies[ $plugin_file ] ) ) {
+			return self::$dependencies[ $plugin_file ];
+		}
+
+		return array();
+	}
+
+	/**
 	 * Determines whether the plugin has unmet dependencies.
 	 *
 	 * @since 6.4.0

--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -153,6 +153,26 @@ class WP_Plugin_Dependencies {
 	}
 
 	/**
+	 * Gets filepaths of plugins that require the dependency.
+	 *
+	 * @since 6.4.0
+	 *
+	 * @param string $slug The dependency's slug.
+	 * @return array An array of dependent plugin filepaths, relative to the plugins directory.
+	 */
+	public static function get_dependents( $slug ) {
+		$dependents = array();
+
+		foreach ( self::$dependencies as $dependent => $dependencies ) {
+			if ( in_array( $slug, $dependencies, true ) ) {
+				$dependents[] = $dependent;
+			}
+		}
+
+		return $dependents;
+	}
+
+	/**
 	 * Determines whether the plugin has unmet dependencies.
 	 *
 	 * @since 6.4.0

--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -479,13 +479,10 @@ class WP_Plugin_Dependencies {
 			$dependency_slugs              = self::sanitize_dependency_slugs( $header['RequiresPlugins'] );
 			self::$dependencies[ $plugin ] = $dependency_slugs;
 			self::$dependency_slugs        = array_merge( self::$dependency_slugs, $dependency_slugs );
-		}
 
-		$dependent_keys = array();
-		foreach ( array_keys( self::$dependencies ) as $dependency ) {
-			$dependent_keys[] = str_contains( $dependency, '/' ) ? dirname( $dependency ) : $dependency;
+			$dependent_slug                           = str_contains( $plugin, '/' ) ? dirname( $plugin ) : $plugin;
+			self::$dependent_slugs[ $dependent_slug ] = $plugin;
 		}
-		self::$dependent_slugs  = array_combine( $dependent_keys, array_map( 'dirname', $dependent_keys ) );
 		self::$dependency_slugs = array_unique( self::$dependency_slugs );
 	}
 


### PR DESCRIPTION
- Simplifies logic to build dependent slugs.
- Adds `get_dependents()` to the public API.
- Adds `get_dependencies()` to the public API.
- Removes `protected` `get_dependents()` and `get_dependencies()`.
- Introduces and implement `convert_to_slug()`.
- Guards against missing filepath in `get_dependency_filepath()`.
- Removes unnecessary `self::$plugins` guard.
- Introduces `get_dependency_filepath()`.
- Fixes erroneous use of `(string) 'requires_plugins'` as an array.