### PR TITLE
Use database before the filesystem when checking that known dependencies are met.

### DIFF
--- a/src/wp-admin/includes/class-plugin-upgrader.php
+++ b/src/wp-admin/includes/class-plugin-upgrader.php
@@ -482,6 +482,7 @@ class Plugin_Upgrader extends WP_Upgrader {
 			foreach ( $files as $file ) {
 				$info = get_plugin_data( $file, false, false );
 				if ( ! empty( $info['Name'] ) ) {
+					$info['File']          = str_replace( trailingslashit( WP_PLUGIN_DIR ), '', $file );
 					$this->new_plugin_data = $info;
 					break;
 				}

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -710,6 +710,20 @@ class WP_Upgrader {
 		if ( is_wp_error( $res ) ) {
 			$this->result = $res;
 			return $res;
+		} elseif ( $this instanceof Plugin_Upgrader && ! empty( $this->new_plugin_data['File'] ) ) {
+			$dependencies = false;
+			if ( ! empty( $this->new_plugin_data['RequiresPlugins'] ) ) {
+				$dependencies = $this->new_plugin_data['RequiresPlugins'];
+				$dependencies = WP_Plugin_Dependencies::sanitize_dependency_slugs( $dependencies );
+			}
+
+			update_site_option(
+				'wp_plugin_dependencies_known_dependencies',
+				array_merge(
+					get_site_option( 'wp_plugin_dependencies_known_dependencies', array() ),
+					array( $this->new_plugin_data['File'] => $dependencies )
+				)
+			);
 		}
 
 		// Bombard the calling function will all the info which we've just used.

--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -573,7 +573,7 @@ class WP_Plugin_Dependencies {
 	 * @param string $slugs A comma-separated string of plugin dependency slugs.
 	 * @return array An array of sanitized plugin dependency slugs.
 	 */
-	protected static function sanitize_dependency_slugs( $slugs ) {
+	public static function sanitize_dependency_slugs( $slugs ) {
 		$sanitized_slugs = array();
 		$slugs           = explode( ',', $slugs );
 

--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -517,6 +517,44 @@ class WP_Plugin_Dependencies {
 	}
 
 	/**
+	 * Sanitizes slugs.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param string $slugs A comma-separated string of plugin dependency slugs.
+	 * @return array An array of sanitized plugin dependency slugs.
+	 */
+	public static function sanitize_dependency_slugs( $slugs ) {
+		$sanitized_slugs = array();
+		$slugs           = explode( ',', $slugs );
+
+		foreach ( $slugs as $slug ) {
+			$slug = trim( $slug );
+
+			/**
+			 * Filters a plugin dependency's slug before matching to
+			 * the WordPress.org slug format.
+			 *
+			 * Can be used to switch between free and premium plugin slugs, for example.
+			 *
+			 * @since 6.5.0
+			 *
+			 * @param string $slug The slug.
+			 */
+			$slug = apply_filters( 'wp_plugin_dependencies_slug', $slug );
+
+			// Match to WordPress.org slug format.
+			if ( preg_match( '/^[a-z0-9]+(-[a-z0-9]+)*$/mu', $slug ) ) {
+				$sanitized_slugs[] = $slug;
+			}
+		}
+		$sanitized_slugs = array_unique( $sanitized_slugs );
+		sort( $sanitized_slugs );
+
+		return $sanitized_slugs;
+	}
+
+	/**
 	 * Stores the result of 'get_plugins()'.
 	 *
 	 * @since 6.5.0
@@ -565,43 +603,6 @@ class WP_Plugin_Dependencies {
 		self::$dependency_slugs = array_unique( self::$dependency_slugs );
 	}
 
-	/**
-	 * Sanitizes slugs.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param string $slugs A comma-separated string of plugin dependency slugs.
-	 * @return array An array of sanitized plugin dependency slugs.
-	 */
-	public static function sanitize_dependency_slugs( $slugs ) {
-		$sanitized_slugs = array();
-		$slugs           = explode( ',', $slugs );
-
-		foreach ( $slugs as $slug ) {
-			$slug = trim( $slug );
-
-			/**
-			 * Filters a plugin dependency's slug before matching to
-			 * the WordPress.org slug format.
-			 *
-			 * Can be used to switch between free and premium plugin slugs, for example.
-			 *
-			 * @since 6.5.0
-			 *
-			 * @param string $slug The slug.
-			 */
-			$slug = apply_filters( 'wp_plugin_dependencies_slug', $slug );
-
-			// Match to WordPress.org slug format.
-			if ( preg_match( '/^[a-z0-9]+(-[a-z0-9]+)*$/mu', $slug ) ) {
-				$sanitized_slugs[] = $slug;
-			}
-		}
-		$sanitized_slugs = array_unique( $sanitized_slugs );
-		sort( $sanitized_slugs );
-
-		return $sanitized_slugs;
-	}
 
 	/**
 	 * Gets plugin filepaths for active plugins that depend on the dependency.


### PR DESCRIPTION
**Note**: Please test this PR before considering it for merge.

This PR introduces a database-first approach when checking that known dependencies are met.

**Initialization**
Plugin Dependencies will check the database for known dependency results.
- If the option is found, each plugin is checked for dependencies, and the respective property values will be set.
- If a value isn't found in the database, the filesystem is checked.

**Plugin Installation (and by proxy, upgrade)**
A plugin is checked for dependencies.
- If the plugin has dependencies, their slugs are sanitized and stored.
- If the plugin doesn't have dependencies, `false` is stored.