### PR TITLE
Don't load in bootstrap during test suite.

### DIFF
--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -396,8 +396,10 @@ wp_plugin_directory_constants();
 $GLOBALS['wp_plugin_paths'] = array();
 
 // Load and initialize WP_Plugin_Dendencies.
-require_once ABSPATH . WPINC . '/class-wp-plugin-dependencies.php';
-WP_Plugin_Dependencies::initialize();
+if ( ! defined( 'WP_RUN_CORE_TESTS' ) ) {
+	require_once ABSPATH . WPINC . '/class-wp-plugin-dependencies.php';
+	WP_Plugin_Dependencies::initialize();
+}
 
 // Load must-use plugins.
 foreach ( wp_get_mu_plugins() as $mu_plugin ) {

--- a/tests/phpunit/tests/admin/plugin-dependencies/base.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/base.php
@@ -45,6 +45,8 @@ abstract class WP_PluginDependencies_UnitTestCase extends WP_UnitTestCase {
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
 
+		require_once ABSPATH . WPINC . '/class-wp-plugin-dependencies.php';
+
 		self::$instance    = new WP_Plugin_Dependencies();
 		self::$plugins_dir = WP_PLUGIN_DIR . '/wp_plugin_dependencies_plugin';
 		@mkdir( self::$plugins_dir );


### PR DESCRIPTION
This prevents Plugin Dependencies from being loaded during Core's bootstrap when tests are running, and instead only includes `WP_Plugin_Dependencies` inside its tests.