### PR TITLE
Test updates.

### DIFF
--- a/tests/phpunit/tests/admin/plugin-dependencies/base.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/base.php
@@ -30,47 +30,28 @@ abstract class WP_PluginDependencies_UnitTestCase extends WP_UnitTestCase {
 		'dependency_slugs'      => array(),
 		'dependent_slugs'       => array(),
 		'dependency_api_data'   => array(),
+		'dependency_filepaths'  => array(),
 	);
 
 	/**
-	 * Stores the plugins directory.
-	 *
-	 * @var string
-	 */
-	protected static $plugins_dir;
-
-	/**
-	 * Sets up the WP_Plugin_Dependencies instance and plugins directory before any tests run.
+	 * Sets up the WP_Plugin_Dependencies instance before any tests run.
 	 */
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
 
 		require_once ABSPATH . WPINC . '/class-wp-plugin-dependencies.php';
-
-		self::$instance    = new WP_Plugin_Dependencies();
-		self::$plugins_dir = WP_PLUGIN_DIR . '/wp_plugin_dependencies_plugin';
-		@mkdir( self::$plugins_dir );
-	}
-
-	/**
-	 * Removes the plugins directory after all tests run.
-	 */
-	public static function tear_down_after_class() {
-		array_map( 'unlink', array_filter( (array) glob( self::$plugins_dir . '/*' ) ) );
-		rmdir( self::$plugins_dir );
-
-		parent::tear_down_after_class();
+		self::$instance = new WP_Plugin_Dependencies();
 	}
 
 	/**
 	 * Resets all static properties to a default value after each test.
 	 */
-	public function tear_down() {
+	public function set_up() {
+		parent::set_up();
+
 		foreach ( self::$static_properties as $name => $default_value ) {
 			$this->set_property_value( $name, $default_value );
 		}
-
-		parent::tear_down();
 	}
 
 	/**

--- a/tests/phpunit/tests/admin/plugin-dependencies/convertToSlug.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/convertToSlug.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Tests for the WP_Plugin_Dependencies::convert_to_slug() method.
+ *
+ * @package WordPress
+ */
+
+require_once __DIR__ . '/base.php';
+
+/**
+ * @group admin
+ * @group plugins
+ *
+ * @covers WP_Plugin_Dependencies::convert_to_slug
+ */
+class Tests_Admin_WPPluginDependencies_ConvertToSlug extends WP_PluginDependencies_UnitTestCase {
+
+	/**
+	 * Tests that a plugin in a directory is slugified.
+	 */
+	public function test_should_return_slug_for_a_plugin_in_a_directory() {
+		$this->set_property_value( 'dependency_slugs', array( 'dependent' ) );
+		$this->assertTrue( $this->call_method( 'has_dependents', 'dependent/dependent.php' ) );
+	}
+
+	/**
+	 * Tests that a single file plugin with dependents will return true.
+	 */
+	public function test_should_return_true_when_a_single_file_plugin_has_dependents() {
+		$this->set_property_value( 'dependency_slugs', array( 'dependent' ) );
+		$this->assertTrue( $this->call_method( 'has_dependents', 'dependent.php' ) );
+	}
+
+	/**
+	 * Tests that a plugin with no dependents will return false.
+	 */
+	public function test_should_return_false_when_a_plugin_has_no_dependents() {
+		$this->set_property_value( 'dependency_slugs', array( 'dependent2' ) );
+		$this->assertFalse( $this->call_method( 'has_dependents', 'dependent/dependent.php' ) );
+	}
+}

--- a/tests/phpunit/tests/admin/plugin-dependencies/getDependencies.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/getDependencies.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Tests for the WP_Plugin_Dependencies::get_dependencies() method.
+ *
+ * @package WordPress
+ */
+
+require_once __DIR__ . '/base.php';
+
+/**
+ * @group admin
+ * @group plugins
+ *
+ * @covers WP_Plugin_Dependencies::get_dependencies
+ */
+class Tests_Admin_WPPluginDependencies_GetDependencies extends WP_PluginDependencies_UnitTestCase {
+
+	/**
+	 * Tests that a plugin with no dependencies will return an empty array.
+	 */
+	public function test_should_return_an_empty_array_when_a_plugin_has_no_dependencies() {
+		$this->assertSame( array(), $this->call_method( 'get_dependencies', 'dependent/dependent.php' ) );
+	}
+
+	/**
+	 * Tests that a plugin with dependencies will return an array of dependencies.
+	 */
+	public function test_should_return_an_array_of_dependencies_when_a_plugin_has_dependencies() {
+		$expected = array( 'dependency', 'dependency2' );
+		$this->set_property_value(
+			'dependencies',
+			array( 'dependent/dependent.php' => $expected )
+		);
+		$this->assertSame( $expected, $this->call_method( 'get_dependencies', 'dependent/dependent.php' ) );
+	}
+}

--- a/tests/phpunit/tests/admin/plugin-dependencies/getDependencyFilepaths.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/getDependencyFilepaths.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the WP_Plugin_Dependencies::get_dependency_filepaths() method.
  *
- * @package WP_Plugin_Dependencies
+ * @package WordPress
  */
 
 require_once __DIR__ . '/base.php';
@@ -157,5 +157,50 @@ class Tests_Admin_WPPluginDependencies_GetDependencyFilepaths extends WP_PluginD
 		);
 
 		$this->assertSame( $expected, $this->call_method( 'get_dependency_filepaths' ) );
+	}
+
+	/**
+	 * Tests that an existing value for dependency filepaths is returned.
+	 */
+	public function test_should_return_existing_value_for_dependency_filepaths() {
+		$expected = array( 'dependent/dependent.php' );
+
+		$this->set_property_value( 'dependency_filepaths', $expected );
+
+		/*
+		 * If existing dependency filepaths are not returned,
+		 * they'll be built from this data.
+		 *
+		 * This data is explicitly set to ensure that no
+		 * test plugins ever interfere with this test.
+		 */
+		$this->set_property_value(
+			'dependency_slugs',
+			array( 'plugin1', 'plugin2', 'plugin3' )
+		);
+
+		$this->set_property_value(
+			'plugins',
+			array(
+				// This is flipped as paths are stored in the keys.
+				'plugin1/plugin1.php' => '',
+				'plugin2/plugin2.php' => '',
+				'plugin3/plugin3.php' => '',
+			)
+		);
+
+		$this->assertSame( $expected, $this->call_method( 'get_dependency_filepaths' ) );
+	}
+
+	/**
+	 * Tests that an empty array is returned when
+	 * no plugin directory names are stored.
+	 */
+	public function test_should_return_empty_array_for_no_plugin_dirnames() {
+		$this->set_property_value( 'plugins', array() );
+		$this->set_property_value( 'plugin_dirnames', array() );
+		$this->set_property_value( 'plugin_dirnames_cache', array() );
+
+		$this->assertSame( array(), $this->call_method( 'get_dependency_filepaths' ) );
 	}
 }

--- a/tests/phpunit/tests/admin/plugin-dependencies/getDependents.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/getDependents.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Tests for the WP_Plugin_Dependencies::get_dependents() method.
+ *
+ * @package WordPress
+ */
+
+require_once __DIR__ . '/base.php';
+
+/**
+ * @group admin
+ * @group plugins
+ *
+ * @covers WP_Plugin_Dependencies::get_dependents
+ */
+class Tests_Admin_WPPluginDependencies_GetDependents extends WP_PluginDependencies_UnitTestCase {
+
+	/**
+	 * Tests that a plugin with no dependents will return an empty array.
+	 */
+	public function test_should_return_an_empty_array_when_a_plugin_has_no_dependents() {
+		$this->assertSame(
+			array(),
+			$this->call_method( 'get_dependencies', 'dependent/dependent.php' )
+		);
+	}
+
+	/**
+	 * Tests that a plugin with dependents will return an array of dependents.
+	 */
+	public function test_should_return_an_array_of_dependents_when_a_plugin_has_dependents() {
+		$this->set_property_value(
+			'dependencies',
+			array(
+				'dependent/dependent.php'   => array( 'dependency' ),
+				'dependent2/dependent2.php' => array( 'dependency' ),
+			),
+		);
+
+		$this->assertSame(
+			array( 'dependent/dependent.php', 'dependent2/dependent2.php' ),
+			$this->call_method( 'get_dependents', 'dependency' )
+		);
+	}
+}

--- a/tests/phpunit/tests/admin/plugin-dependencies/getPlugins.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/getPlugins.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the WP_Plugin_Dependencies::get_plugins() method.
  *
- * @package WP_Plugin_Dependencies
+ * @package WordPress
  */
 
 require_once __DIR__ . '/base.php';

--- a/tests/phpunit/tests/admin/plugin-dependencies/hasActiveDependents.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/hasActiveDependents.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Tests for the WP_Plugin_Dependencies::has_active_dependents() method.
+ *
+ * @package WordPress
+ */
+
+require_once __DIR__ . '/base.php';
+
+/**
+ * @group admin
+ * @group plugins
+ *
+ * @covers WP_Plugin_Dependencies::has_active_dependents
+ */
+class Tests_Admin_WPPluginDependencies_HasActiveDependents extends WP_PluginDependencies_UnitTestCase {
+
+	/**
+	 * Tests that a plugin with no dependents will return true.
+	 */
+	public function test_should_return_false_when_a_plugin_has_no_dependents() {
+		$this->set_property_value(
+			'dependencies',
+			array( 'dependent/dependent.php' => array( 'dependency' ) )
+		);
+
+		update_option( 'active_plugins', array( 'dependent/dependent.php' ) );
+
+		$this->assertFalse( $this->call_method( 'has_active_dependents', 'dependency2/dependency2.php' ) );
+	}
+
+	/**
+	 * Tests that a plugin with active dependents will return true.
+	 */
+	public function test_should_return_true_when_a_plugin_has_active_dependents() {
+		$this->set_property_value(
+			'dependencies',
+			array( 'dependent/dependent.php' => array( 'dependency' ) )
+		);
+
+		update_option( 'active_plugins', array( 'dependent/dependent.php' ) );
+
+		$this->assertTrue( $this->call_method( 'has_active_dependents', 'dependency/dependency.php' ) );
+	}
+
+	/**
+	 * Tests that a plugin with one inactive and one active dependent will return true.
+	 */
+	public function test_should_return_true_when_a_plugin_has_one_inactive_and_one_active_dependent() {
+		$this->set_property_value(
+			'dependencies',
+			array(
+				'dependent2/dependent2.php' => array( 'dependency' ),
+				'dependent/dependent.php'   => array( 'dependency' ),
+			)
+		);
+
+		update_option( 'active_plugins', array( 'dependent/dependent.php' ) );
+
+		$this->assertTrue( $this->call_method( 'has_active_dependents', 'dependency/dependency.php' ) );
+	}
+
+	/**
+	 * Tests that a plugin with one active and one inactive dependent will return true.
+	 */
+	public function test_should_return_true_when_a_plugin_has_one_active_and_one_inactive_dependent() {
+		$this->set_property_value(
+			'dependencies',
+			array(
+				'dependent/dependent.php'   => array( 'dependency' ),
+				'dependent2/dependent2.php' => array( 'dependency' ),
+			)
+		);
+
+		update_option( 'active_plugins', array( 'dependent/dependent.php' ) );
+
+		$this->assertTrue( $this->call_method( 'has_active_dependents', 'dependency/dependency.php' ) );
+	}
+
+	/**
+	 * Tests that when a plugin with active dependents is earlier in the list,
+	 * it will return true if a later plugin has no active dependents.
+	 */
+	public function test_should_return_true_when_the_earlier_plugin_has_active_dependents_but_the_later_plugin_does_not() {
+		$this->set_property_value(
+			'dependencies',
+			array( 'dependent2/dependent2.php' => array( 'dependency' ) )
+		);
+
+		$this->set_property_value(
+			'dependencies',
+			array(
+				'dependent/dependent.php'   => array( 'dependency' ),
+				'dependent2/dependent2.php' => array( 'dependency2' ),
+			)
+		);
+
+		update_option( 'active_plugins', array( 'dependent/dependent.php' ) );
+
+		$this->assertTrue( $this->call_method( 'has_active_dependents', 'dependency/dependency.php' ) );
+	}
+
+	/**
+	 * Tests that when a plugin with active dependents is later in the list,
+	 * it will return true if an earlier plugin has no active dependents.
+	 */
+	public function test_should_return_true_when_the_later_plugin_has_active_dependents_but_the_earlier_plugin_does_not() {
+		$this->set_property_value(
+			'dependencies',
+			array( 'dependent2/dependent2.php' => array( 'dependency' ) )
+		);
+
+		$this->set_property_value(
+			'dependencies',
+			array(
+				'dependent/dependent.php'   => array( 'dependency' ),
+				'dependent2/dependent2.php' => array( 'dependency2' ),
+			)
+		);
+
+		update_option( 'active_plugins', array( 'dependent2/dependent2.php' ) );
+
+		$this->assertTrue( $this->call_method( 'has_active_dependents', 'dependency2/dependency2.php' ) );
+	}
+
+	/**
+	 * Tests that a plugin with no dependents will return false.
+	 */
+	public function test_should_return_false_when_a_plugin_has_no_active_dependents() {
+		$this->set_property_value(
+			'dependencies',
+			array( 'dependent/dependent.php' => array( 'dependency' ) )
+		);
+
+		$this->assertFalse( $this->call_method( 'has_active_dependents', 'dependency/dependency.php' ) );
+	}
+
+	/**
+	 * Tests that when a plugin with no active dependents is earlier in the list,
+	 * it will return false if a later plugin has active dependents.
+	 */
+	public function test_should_return_false_when_the_earlier_plugin_has_no_active_dependents_but_the_later_plugin_does() {
+		$this->set_property_value(
+			'dependencies',
+			array( 'dependent2/dependent2.php' => array( 'dependency' ) )
+		);
+
+		$this->set_property_value(
+			'dependencies',
+			array(
+				'dependent/dependent.php'   => array( 'dependency' ),
+				'dependent2/dependent2.php' => array( 'dependency2' ),
+			)
+		);
+
+		update_option( 'active_plugins', array( 'dependent2/dependent2.php' ) );
+
+		$this->assertFalse( $this->call_method( 'has_active_dependents', 'dependency/dependency.php' ) );
+	}
+
+	/**
+	 * Tests that when a plugin with no active dependents is later in the list,
+	 * it will return false if an earlier plugin has active dependents.
+	 */
+	public function test_should_return_false_when_the_later_plugin_has_no_active_dependents_but_the_earlier_plugin_does() {
+		$this->set_property_value(
+			'dependencies',
+			array( 'dependent2/dependent2.php' => array( 'dependency' ) )
+		);
+
+		$this->set_property_value(
+			'dependencies',
+			array(
+				'dependent/dependent.php'   => array( 'dependency' ),
+				'dependent2/dependent2.php' => array( 'dependency2' ),
+			)
+		);
+
+		update_option( 'active_plugins', array( 'dependent/dependent.php' ) );
+
+		$this->assertFalse( $this->call_method( 'has_active_dependents', 'dependency2/dependency2.php' ) );
+	}
+}

--- a/tests/phpunit/tests/admin/plugin-dependencies/hasDependencies.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/hasDependencies.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Tests for the WP_Plugin_Dependencies::has_dependencies() method.
+ *
+ * @package WordPress
+ */
+
+require_once __DIR__ . '/base.php';
+
+/**
+ * @group admin
+ * @group plugins
+ *
+ * @covers WP_Plugin_Dependencies::has_dependencies
+ */
+class Tests_Admin_WPPluginDependencies_HasDependencies extends WP_PluginDependencies_UnitTestCase {
+
+	/**
+	 * Tests that a plugin with dependencies will return true.
+	 */
+	public function test_should_return_true_when_a_plugin_has_dependencies() {
+		$this->set_property_value( 'dependencies', array( 'dependent/dependent.php' => array() ) );
+		$this->assertTrue( $this->call_method( 'has_dependencies', 'dependent/dependent.php' ) );
+	}
+
+	/**
+	 * Tests that a plugin with no dependencies will return false.
+	 */
+	public function test_should_return_false_when_a_plugin_has_no_dependencies() {
+		$this->set_property_value( 'dependencies', array( 'dependent2/dependent2.php' => array() ) );
+		$this->assertFalse( $this->call_method( 'has_dependencies', 'dependent/dependent.php' ) );
+	}
+}

--- a/tests/phpunit/tests/admin/plugin-dependencies/hasDependents.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/hasDependents.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Tests for the WP_Plugin_Dependencies::has_dependents() method.
+ *
+ * @package WordPress
+ */
+
+require_once __DIR__ . '/base.php';
+
+/**
+ * @group admin
+ * @group plugins
+ *
+ * @covers WP_Plugin_Dependencies::has_dependents
+ */
+class Tests_Admin_WPPluginDependencies_HasDependents extends WP_PluginDependencies_UnitTestCase {
+
+	/**
+	 * Tests that a plugin with dependents will return true.
+	 */
+	public function test_should_return_true_when_a_plugin_has_dependents() {
+		$this->set_property_value( 'dependency_slugs', array( 'dependent' ) );
+		$this->assertTrue( $this->call_method( 'has_dependents', 'dependent/dependent.php' ) );
+	}
+
+	/**
+	 * Tests that a single file plugin with dependents will return true.
+	 */
+	public function test_should_return_true_when_a_single_file_plugin_has_dependents() {
+		$this->set_property_value( 'dependency_slugs', array( 'dependent' ) );
+		$this->assertTrue( $this->call_method( 'has_dependents', 'dependent.php' ) );
+	}
+
+	/**
+	 * Tests that a plugin with no dependents will return false.
+	 */
+	public function test_should_return_false_when_a_plugin_has_no_dependents() {
+		$this->set_property_value( 'dependency_slugs', array( 'dependent2' ) );
+		$this->assertFalse( $this->call_method( 'has_dependents', 'dependent/dependent.php' ) );
+	}
+}

--- a/tests/phpunit/tests/admin/plugin-dependencies/hasUnmetDependencies.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/hasUnmetDependencies.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Tests for the WP_Plugin_Dependencies::has_unmet_dependencies() method.
+ *
+ * @package WordPress
+ */
+
+require_once __DIR__ . '/base.php';
+
+/**
+ * @group admin
+ * @group plugins
+ *
+ * @covers WP_Plugin_Dependencies::has_unmet_dependencies
+ */
+class Tests_Admin_WPPluginDependencies_HasUnmetDependencies extends WP_PluginDependencies_UnitTestCase {
+
+	/**
+	 * Tests that a plugin with no dependencies will return false.
+	 */
+	public function test_should_return_false_when_a_plugin_has_no_dependencies() {
+		$this->set_property_value( 'dependencies', array( 'dependent/dependent.php' => array( 'dependency' ) ) );
+		$this->assertFalse( $this->call_method( 'has_unmet_dependencies', 'dependent2/dependent2.php' ) );
+	}
+
+	/**
+	 * Tests that a plugin whose dependencies are installed and active will return false.
+	 */
+	public function test_should_return_false_when_a_plugin_has_no_unmet_dependencies() {
+		$this->set_property_value(
+			'dependencies',
+			array( 'dependent/dependent.php' => array( 'dependency' ) )
+		);
+
+		$this->set_property_value(
+			'dependency_filepaths',
+			array( 'dependency' => 'dependency/dependency.php' )
+		);
+
+		update_option( 'active_plugins', array( 'dependency/dependency.php' ) );
+
+		$this->assertFalse( $this->call_method( 'has_unmet_dependencies', 'dependent/dependent.php' ) );
+	}
+
+	/**
+	 * Tests that a plugin with a dependency that is not installed will return true.
+	 */
+	public function test_should_return_true_when_a_plugin_has_a_dependency_that_is_not_installed() {
+		$this->set_property_value(
+			'dependencies',
+			array( 'dependent/dependent.php' => array( 'dependency' ) )
+		);
+
+		$this->assertTrue( $this->call_method( 'has_unmet_dependencies', 'dependent/dependent.php' ) );
+	}
+
+	/**
+	 * Tests that a plugin with a dependency that is inactive will return true.
+	 */
+	public function test_should_return_true_when_a_plugin_has_a_dependency_that_is_inactive() {
+		$this->set_property_value(
+			'dependencies',
+			array( 'dependent/dependent.php' => array( 'dependency' ) )
+		);
+
+		$this->set_property_value(
+			'dependency_filepaths',
+			array( 'dependency' => 'dependency/dependency.php' )
+		);
+
+		$this->assertTrue( $this->call_method( 'has_unmet_dependencies', 'dependent/dependent.php' ) );
+	}
+
+	/**
+	 * Tests that a plugin with one dependency that is active and one dependency that is inactive will return true.
+	 */
+	public function test_should_return_true_when_a_plugin_has_one_active_dependency_and_one_inactive_dependency() {
+		$this->set_property_value(
+			'dependencies',
+			array( 'dependent/dependent.php' => array( 'dependency', 'dependency2' ) )
+		);
+
+		$this->set_property_value(
+			'dependency_filepaths',
+			array(
+				'dependency'  => 'dependency/dependency.php',
+				'dependency2' => 'dependency2/dependency2.php',
+			)
+		);
+
+		update_option( 'active_plugins', array( 'dependency/dependency.php' ) );
+
+		$this->assertTrue( $this->call_method( 'has_unmet_dependencies', 'dependent/dependent.php' ) );
+	}
+
+	/**
+	 * Tests that a plugin with one dependency that is active and one dependency that is not installed will return true.
+	 */
+	public function test_should_return_true_when_a_plugin_has_one_active_dependency_and_one_that_is_not_installed() {
+		$this->set_property_value(
+			'dependencies',
+			array( 'dependent/dependent.php' => array( 'dependency', 'dependency2' ) )
+		);
+
+		$this->set_property_value(
+			'dependency_filepaths',
+			array( 'dependency' => 'dependency/dependency.php' )
+		);
+
+		update_option( 'active_plugins', array( 'dependency/dependency.php' ) );
+
+		$this->assertTrue( $this->call_method( 'has_unmet_dependencies', 'dependent/dependent.php' ) );
+	}
+
+	/**
+	 * Tests that a plugin with one dependency that is inactive and one dependency that is not installed will return true.
+	 */
+	public function test_should_return_true_when_a_plugin_has_one_inactive_dependency_and_one_that_is_not_installed() {
+		$this->set_property_value(
+			'dependencies',
+			array( 'dependent/dependent.php' => array( 'dependency', 'dependency2' ) )
+		);
+
+		$this->set_property_value(
+			'dependency_filepaths',
+			array( 'dependency' => 'dependency/dependency.php' )
+		);
+
+		$this->assertTrue( $this->call_method( 'has_unmet_dependencies', 'dependent/dependent.php' ) );
+	}
+}

--- a/tests/phpunit/tests/admin/plugin-dependencies/initialize.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/initialize.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the WP_Plugin_Dependencies::initialize() method.
  *
- * @package WP_Plugin_Dependencies
+ * @package WordPress
  */
 
 require_once __DIR__ . '/base.php';

--- a/tests/phpunit/tests/admin/plugin-dependencies/sanitizeDependencySlugs.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/sanitizeDependencySlugs.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the WP_Plugin_Dependencies::sanitize_dependency_slugs() method.
  *
- * @package WP_Plugin_Dependencies
+ * @package WordPress
  */
 
 require_once __DIR__ . '/base.php';


### PR DESCRIPTION
This updates the tests to add some coverage to the `WP_Plugin_Dependencies` class after the refactor.

Here's how things stand with this PR:
![image](https://github.com/afragen/wordpress-develop/assets/79332690/5c260d50-c993-495a-91ac-6646a73e03c5)
