### PR TITLE
Plugin Dependencies: Use a database-first approach.

### DIFF
--- a/src/wp-admin/includes/class-plugin-upgrader.php
+++ b/src/wp-admin/includes/class-plugin-upgrader.php
@@ -155,6 +155,12 @@ class Plugin_Upgrader extends WP_Upgrader {
 		// Force refresh of plugin update information.
 		wp_clean_plugins_cache( $parsed_args['clear_update_cache'] );
 
+		$all_plugin_data = get_option( 'plugin_data', array() );
+		$plugin_file     = $this->new_plugin_data['file'];
+		unset( $this->new_plugin_data['file'] );
+		$all_plugin_data[ $plugin_file ] = $this->new_plugin_data;
+		update_option( 'plugin_data', $all_plugin_data );
+
 		if ( $parsed_args['overwrite_package'] ) {
 			/**
 			 * Fires when the upgrader has successfully overwritten a currently installed
@@ -482,7 +488,16 @@ class Plugin_Upgrader extends WP_Upgrader {
 			foreach ( $files as $file ) {
 				$info = get_plugin_data( $file, false, false );
 				if ( ! empty( $info['Name'] ) ) {
-					$this->new_plugin_data = $info;
+					$basename = basename( $file );
+					$dirname  = basename( dirname( $file ) );
+
+					if ( '.' === $dirname ) {
+						$plugin_file = $basename;
+					} else {
+						$plugin_file = "$dirname/$basename";
+					}
+					$this->new_plugin_data         = ( $info );
+					$this->new_plugin_data['file'] = $plugin_file;
 					break;
 				}
 			}

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -955,6 +955,7 @@ function delete_plugins( $plugins, $deprecated = '' ) {
 	$plugins_dir = trailingslashit( $plugins_dir );
 
 	$plugin_translations = wp_get_installed_translations( 'plugins' );
+	$all_plugin_data     = get_option( 'plugin_data', array() );
 
 	$errors = array();
 
@@ -999,6 +1000,7 @@ function delete_plugins( $plugins, $deprecated = '' ) {
 			$errors[] = $plugin_file;
 			continue;
 		}
+		unset( $all_plugin_data[ $plugin_file ] );
 
 		$plugin_slug = dirname( $plugin_file );
 
@@ -1047,6 +1049,7 @@ function delete_plugins( $plugins, $deprecated = '' ) {
 
 		return new WP_Error( 'could_not_remove_plugin', sprintf( $message, implode( ', ', $errors ) ) );
 	}
+	update_option( 'plugin_data', $all_plugin_data );
 
 	return true;
 }

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -352,6 +352,7 @@ function get_plugins( $plugin_folder = '' ) {
 
 	$cache_plugins[ $plugin_folder ] = $wp_plugins;
 	wp_cache_set( 'plugins', $cache_plugins, 'plugins' );
+	update_option( 'plugin_data', $wp_plugins );
 
 	return $wp_plugins;
 }

--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -7,6 +7,8 @@
  * @since 6.5.0
  */
 
+require_once ABSPATH . '/wp-admin/includes/plugin.php';
+
 /**
  * Core class for installing plugin dependencies.
  *

--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -7,8 +7,6 @@
  * @since 6.5.0
  */
 
-require_once ABSPATH . '/wp-admin/includes/plugin.php';
-
 /**
  * Core class for installing plugin dependencies.
  *
@@ -142,8 +140,9 @@ class WP_Plugin_Dependencies {
 	 * @return bool Whether the plugin has active dependents.
 	 */
 	public static function has_active_dependents( $plugin_file ) {
-		$dependents = self::get_dependents( self::convert_to_slug( $plugin_file ) );
+		require_once ABSPATH . '/wp-admin/includes/plugin.php';
 
+		$dependents = self::get_dependents( self::convert_to_slug( $plugin_file ) );
 		foreach ( $dependents as $dependent ) {
 			if ( is_plugin_active( $dependent ) ) {
 				return true;
@@ -218,6 +217,8 @@ class WP_Plugin_Dependencies {
 		if ( ! isset( self::$dependencies[ $plugin_file ] ) ) {
 			return false;
 		}
+
+		require_once ABSPATH . '/wp-admin/includes/plugin.php';
 
 		foreach ( self::$dependencies[ $plugin_file ] as $dependency ) {
 			$dependency_filepath = self::get_dependency_filepath( $dependency );
@@ -463,6 +464,8 @@ class WP_Plugin_Dependencies {
 			wp_send_json_success( $status );
 		}
 
+		require_once ABSPATH . '/wp-admin/includes/plugin.php';
+
 		$inactive_dependencies = array();
 		foreach ( $dependencies as $dependency ) {
 			if ( false === self::$plugin_dirnames[ $dependency ] || is_plugin_inactive( self::$plugin_dirnames[ $dependency ] ) ) {
@@ -511,6 +514,7 @@ class WP_Plugin_Dependencies {
 		$all_plugin_data = get_option( 'plugin_data', array() );
 
 		if ( empty( $all_plugin_data ) ) {
+			require_once ABSPATH . '/wp-admin/includes/plugin.php';
 			$all_plugin_data = get_plugins();
 		}
 
@@ -596,6 +600,7 @@ class WP_Plugin_Dependencies {
 			return $all_dependents;
 		}
 
+		require_once ABSPATH . '/wp-admin/includes/plugin.php';
 		foreach ( $dependents as $dependent ) {
 			if ( is_plugin_active( $dependent ) ) {
 				$all_dependents[] = $dependent;
@@ -624,6 +629,7 @@ class WP_Plugin_Dependencies {
 			array()
 		);
 
+		require_once ABSPATH . '/wp-admin/includes/plugin.php';
 		foreach ( self::$dependencies as $dependent => $dependencies ) {
 			// Skip dependents that are no longer installed or aren't active.
 			if ( ! array_key_exists( $dependent, self::$plugins ) || is_plugin_inactive( $dependent ) ) {

--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -504,10 +504,17 @@ class WP_Plugin_Dependencies {
 	 * @since 6.5.0
 	 */
 	protected static function get_plugins() {
-		if ( ! function_exists( 'get_plugins' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		if ( ! empty( self::$plugins ) ) {
+			return self::$plugins;
 		}
-		self::$plugins = get_plugins();
+
+		$all_plugin_data = get_option( 'plugin_data', array() );
+
+		if ( empty( $all_plugin_data ) ) {
+			$all_plugin_data = get_plugins();
+		}
+
+		self::$plugins = $all_plugin_data;
 	}
 
 	/**

--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -516,20 +516,9 @@ class WP_Plugin_Dependencies {
 	 * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
 	 */
 	protected static function read_dependencies_from_plugin_headers() {
-		global $wp_filesystem;
+		$all_plugin_data = get_option( 'plugin_data', array() );
 
-		if ( ! $wp_filesystem ) {
-			require_once ABSPATH . '/wp-admin/includes/file.php';
-			WP_Filesystem();
-		}
-
-		self::get_plugins();
-		$plugins_dir     = trailingslashit( $wp_filesystem->wp_plugins_dir() );
-		$default_headers = array( 'RequiresPlugins' => 'Requires Plugins' );
-
-		foreach ( array_keys( self::$plugins ) as $plugin ) {
-			$header = get_file_data( $plugins_dir . $plugin, $default_headers, 'plugin' );
-
+		foreach ( $all_plugin_data as $plugin => $header ) {
 			if ( '' === $header['RequiresPlugins'] ) {
 				continue;
 			}

--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -771,6 +771,10 @@ class WP_Plugin_Dependencies {
 			self::$plugin_dirnames       = array();
 			self::$plugin_dirnames_cache = self::$plugins;
 
+			if ( empty( self::$plugins ) ) {
+				self::get_plugins();
+			}
+
 			foreach ( array_keys( self::$plugins ) as $plugin ) {
 				$slug                           = self::convert_to_slug( $plugin );
 				self::$plugin_dirnames[ $slug ] = $plugin;

--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -891,6 +891,9 @@ class WP_Plugin_Dependencies {
 	 * @return string The plugin's slug.
 	 */
 	private static function convert_to_slug( $plugin_file ) {
+		if ( 'hello.php' === $plugin_file ) {
+			return 'hello-dolly';
+		}
 		return str_contains( $plugin_file, '/' ) ? dirname( $plugin_file ) : str_replace( '.php', '', $plugin_file );
 	}
 }

--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -242,7 +242,7 @@ class WP_Plugin_Dependencies {
 		$dependent_names = array();
 
 		if ( empty( self::$plugins ) ) {
-			self::$plugins = get_plugins();
+			self::$plugins = self::get_plugins();
 		}
 
 		$slug = self::convert_to_slug( $plugin_file );

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -489,7 +489,78 @@ if ( ! is_multisite() && wp_is_fatal_error_handler_enabled() ) {
 }
 
 // Load active plugins.
+$all_plugin_data    = get_option( 'plugin_data', array() );
+$failed_plugins     = array();
+$update_plugin_data = false;
 foreach ( wp_get_active_and_valid_plugins() as $plugin ) {
+	$plugin_file = str_replace( trailingslashit( WP_PLUGIN_DIR ), '', $plugin );
+	if ( ! isset( $all_plugin_data[ $plugin_file ] ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		$all_plugin_data[ $plugin_file ] = get_plugin_data( WP_PLUGIN_DIR . "/$plugin_file" );
+
+		$update_plugin_data = true;
+	}
+
+	$plugin_headers = $all_plugin_data[ $plugin_file ];
+	$error_message  = '';
+	$requirements   = array(
+		'requires'     => ! empty( $plugin_headers['RequiresWP'] ) ? $plugin_headers['RequiresWP'] : '',
+		'requires_php' => ! empty( $plugin_headers['RequiresPHP'] ) ? $plugin_headers['RequiresPHP'] : '',
+	);
+	$compatible_wp  = is_wp_version_compatible( $requirements['requires'] );
+	$compatible_php = is_php_version_compatible( $requirements['requires_php'] );
+
+	$php_update_message = '</p><p>' . sprintf(
+		/* translators: %s: URL to Update PHP page. */
+		__( '<a href="%s">Learn more about updating PHP</a>.' ),
+		esc_url( wp_get_update_php_url() )
+	);
+
+	$annotation = wp_get_update_php_annotation();
+
+	if ( $annotation ) {
+		$php_update_message .= '</p><p><em>' . $annotation . '</em>';
+	}
+
+	if ( ! $compatible_wp && ! $compatible_php ) {
+		$error_message = sprintf(
+			/* translators: 1: Current WordPress version, 2: Current PHP version, 3: Plugin name, 4: Required WordPress version, 5: Required PHP version. */
+			_x( '<strong>Error:</strong> Current versions of WordPress (%1$s) and PHP (%2$s) do not meet minimum requirements for %3$s. The plugin requires WordPress %4$s and PHP %5$s.', 'plugin' ),
+			get_bloginfo( 'version' ),
+			PHP_VERSION,
+			$plugin_headers['Name'],
+			$requirements['requires'],
+			$requirements['requires_php']
+		) . $php_update_message;
+	} elseif ( ! $compatible_php ) {
+		$error_message = sprintf(
+			/* translators: 1: Current PHP version, 2: Plugin name, 3: Required PHP version. */
+			_x( '<strong>Error:</strong> Current PHP version (%1$s) does not meet minimum requirements for %2$s. The plugin requires PHP %3$s.', 'plugin' ),
+			PHP_VERSION,
+			$plugin_headers['Name'],
+			$requirements['requires_php']
+		) . $php_update_message;
+	} elseif ( ! $compatible_wp ) {
+		$error_message = sprintf(
+			/* translators: 1: Current WordPress version, 2: Plugin name, 3: Required WordPress version. */
+			_x( '<strong>Error:</strong> Current WordPress version (%1$s) does not meet minimum requirements for %2$s. The plugin requires WordPress %3$s.', 'plugin' ),
+			get_bloginfo( 'version' ),
+			$plugin_headers['Name'],
+			$requirements['requires']
+		);
+	}
+
+	if ( '' !== $error_message ) {
+		$failed_plugins[ $plugin_file ] = wp_get_admin_notice(
+			$error_message,
+			array(
+				'type'        => 'error',
+				'dismissible' => true,
+			)
+		);
+		continue;
+	}
+
 	wp_register_plugin_realpath( $plugin );
 
 	$_wp_plugin_file = $plugin;
@@ -506,6 +577,20 @@ foreach ( wp_get_active_and_valid_plugins() as $plugin ) {
 	do_action( 'plugin_loaded', $plugin );
 }
 unset( $plugin, $_wp_plugin_file );
+
+if ( $update_plugin_data ) {
+	update_option( 'plugin_data', $all_plugin_data );
+}
+
+if ( ! empty( $failed_plugins ) ) {
+	add_action(
+		'admin_notices',
+		function () use ( $failed_plugins ) {
+			echo implode( '', $failed_plugins );
+		}
+	);
+}
+unset( $failed_plugins );
 
 // Load pluggable functions.
 require ABSPATH . WPINC . '/pluggable.php';

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -586,7 +586,11 @@ if ( ! empty( $failed_plugins ) ) {
 	add_action(
 		'admin_notices',
 		function () use ( $failed_plugins ) {
-			echo implode( '', $failed_plugins );
+			global $pagenow;
+
+			if ( 'index.php' === $pagenow || 'plugins.php' === $pagenow ) {
+				echo implode( '', $failed_plugins );
+			}
 		}
 	);
 }


### PR DESCRIPTION
### Do not merge without testing first.

This PR implements a database-first approach before looking to the filesystem.

Plugin data is retrieved from the filesystem:
- for active plugins whose data is not in the database during Bootstrap/Load.
- for all plugins when visiting `Plugins > Installed Plugins` (already in Core for years, not part of Plugin Dependencies).

Plugin data is updated from the filesystem:
- for a plugin that has been successfully installed or upgraded.
- for all plugins when visiting `Plugins > Installed Plugins` (since Core already retrieves this on every load of this page).

Plugin data is deleted from the database:
- for a plugin that has been successfully deleted (via `delete_plugins()`).