### PR TITLE
Plugin Dependencies: Remove invalid plugins from `plugin_data` option

### DIFF
--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -986,6 +986,7 @@ function wp_get_active_and_valid_plugins() {
 
 	$network_plugins = is_multisite() ? wp_get_active_network_plugins() : false;
 
+	$invalid_plugins = array();
 	foreach ( $active_plugins as $plugin ) {
 		if ( ! validate_file( $plugin )                     // $plugin must validate as file.
 			&& str_ends_with( $plugin, '.php' )             // $plugin must end with '.php'.
@@ -994,6 +995,20 @@ function wp_get_active_and_valid_plugins() {
 			&& ( ! $network_plugins || ! in_array( WP_PLUGIN_DIR . '/' . $plugin, $network_plugins, true ) )
 		) {
 			$plugins[] = WP_PLUGIN_DIR . '/' . $plugin;
+		} else {
+			$invalid_plugins[] = $plugin;
+		}
+	}
+
+	if ( ! empty( $invalid_plugins ) ) {
+		$all_plugin_data = get_option( 'plugin_data', array() );
+
+		if ( ! empty( $all_plugin_data ) ) {
+			foreach ( $invalid_plugins as $invalid_plugin ) {
+				unset( $all_plugin_data[ $invalid_plugin ] );
+			}
+
+			update_option( 'plugin_data', $all_plugin_data );
 		}
 	}
 


### PR DESCRIPTION
Invalid plugins are not loaded by WordPress Core, such as those that have been renamed or deleted. However, the invalid's plugin data remains in the `plugin_data` option.

Let's clean things up when we find invalid plugins by removing those plugins from the `plugin_data` option.