### PR TITLE
Plugin Dependencies: Only get dependency API data on `plugins.php` and `plugin-install.php`.

### DIFF
--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -696,8 +696,16 @@ class WP_Plugin_Dependencies {
 	 * Retrieves and stores dependency plugin data from the WordPress.org Plugin API.
 	 *
 	 * @since 6.5.0
+	 *
+	 * @global string $pagenow The filename of the current screen.
 	 */
 	protected static function get_dependency_api_data() {
+		global $pagenow;
+
+		if ( ! is_admin() || ( 'plugins.php' !== $pagenow && 'plugin-install.php' !== $pagenow ) ) {
+			return;
+		}
+
 		self::$dependency_api_data = (array) get_site_transient( 'wp_plugin_dependencies_plugin_data' );
 		foreach ( self::$dependency_slugs as $slug ) {
 			// Set transient for individual data, remove from self::$dependency_api_data if transient expired.


### PR DESCRIPTION
Currently, `WP_Plugin_Dependencies::get_dependency_api_data()` runs on every page load. This has a noticeable impact when browsing the site. Commenting out this line shows a noticeable improvement.

Dependency API data should only be necessary on `plugins.php` and `plugin-install.php`.

This PR adds a guard to `WP_Plugin_Dependencies::get_dependency_api_data()` which returns early if the user is not on an admin page or if `$pagenow` is not `plugins.php` or `plugin-install.php`.