### PR TITLE
Plugin Dependencies: Require the class in Core's bootstrap, but just don't initialize it during tests.

### DIFF
--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -409,9 +409,9 @@ wp_plugin_directory_constants();
 
 $GLOBALS['wp_plugin_paths'] = array();
 
-// Load and initialize WP_Plugin_Dendencies.
+// Load and initialize WP_Plugin_Dependencies.
+require_once ABSPATH . WPINC . '/class-wp-plugin-dependencies.php';
 if ( ! defined( 'WP_RUN_CORE_TESTS' ) ) {
-	require_once ABSPATH . WPINC . '/class-wp-plugin-dependencies.php';
 	WP_Plugin_Dependencies::initialize();
 }
 

--- a/tests/phpunit/tests/admin/plugin-dependencies/base.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/base.php
@@ -39,7 +39,6 @@ abstract class WP_PluginDependencies_UnitTestCase extends WP_UnitTestCase {
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
 
-		require_once ABSPATH . WPINC . '/class-wp-plugin-dependencies.php';
 		self::$instance = new WP_Plugin_Dependencies();
 	}
 


### PR DESCRIPTION
Previously, the inclusion of the `WP_Plugin_Dependencies()` was also conditional, causing a Fatal Error during test runs with internal callstacks requiring it.

This moves the `require_once` out of the conditional.