### PR TITLE
Plugin Dependencies: Add a test to ensure that `hello.php` is converted to `hello-dolly`.

### DIFF
--- a/tests/phpunit/tests/admin/plugin-dependencies/convertToSlug.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/convertToSlug.php
@@ -38,4 +38,12 @@ class Tests_Admin_WPPluginDependencies_ConvertToSlug extends WP_PluginDependenci
 		$this->set_property_value( 'dependency_slugs', array( 'dependent2' ) );
 		$this->assertFalse( $this->call_method( 'has_dependents', 'dependent/dependent.php' ) );
 	}
+
+	/**
+	 * Tests that 'hello.php' is converted to 'hello-dolly'.
+	 */
+	public function test_should_convert_hellophp_to_hello_dolly() {
+		$this->set_property_value( 'dependency_slugs', array( 'hello-dolly' ) );
+		$this->assertTrue( $this->call_method( 'has_dependents', 'hello.php' ) );
+	}
 }


### PR DESCRIPTION
Hello Dolly requires special handling as it is, by default, a single file plugin called `hello.php`. However, when installed via the Plugins Repository, it is placed in a nested directory called `hello-dolly`. The correct slug for Hello Dolly is therefore `hello-dolly`, not `hello`.

Recent commits to Plugin Dependencies added this special handling which exists elsewhere in Core which was manually tested.

This PR adds a PHPUnit unit to verify and protect the behaviour.