### PR TITLE
Plugin Dependencies: Fix circular dependencies

### DIFF
--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -754,9 +754,10 @@ class WP_Plugins_List_Table extends WP_List_Table {
 		$compatible_php = is_php_version_compatible( $requires_php );
 		$compatible_wp  = is_wp_version_compatible( $requires_wp );
 
-		$has_dependents         = WP_Plugin_Dependencies::has_dependents( $plugin_file );
-		$has_active_dependents  = WP_Plugin_Dependencies::has_active_dependents( $plugin_file );
-		$has_unmet_dependencies = WP_Plugin_Dependencies::has_unmet_dependencies( $plugin_file );
+		$has_dependents          = WP_Plugin_Dependencies::has_dependents( $plugin_file );
+		$has_active_dependents   = WP_Plugin_Dependencies::has_active_dependents( $plugin_file );
+		$has_unmet_dependencies  = WP_Plugin_Dependencies::has_unmet_dependencies( $plugin_file );
+		$has_circular_dependency = WP_Plugin_Dependencies::has_circular_dependency( $plugin_file );
 
 		if ( 'mustuse' === $context ) {
 			$is_active = true;
@@ -856,7 +857,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 					}
 
 					if ( current_user_can( 'delete_plugins' ) && ! is_plugin_active( $plugin_file ) ) {
-						if ( $has_dependents ) {
+						if ( $has_dependents && ! $has_circular_dependency ) {
 							$actions['delete'] = __( 'Delete' ) .
 								'<span class="screen-reader-text">' .
 								__( 'You cannot delete this plugin as other plugins require it.' ) .
@@ -962,7 +963,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 					}
 
 					if ( ! is_multisite() && current_user_can( 'delete_plugins' ) ) {
-						if ( $has_dependents ) {
+						if ( $has_dependents && ! $has_circular_dependency ) {
 							$actions['delete'] = __( 'Delete' ) .
 								'<span class="screen-reader-text">' .
 								__( 'You cannot delete this plugin as other plugins require it.' ) .

--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -426,9 +426,9 @@ class WP_Plugin_Dependencies {
 			wp_admin_notice(
 				sprintf(
 					'<p>%1$s</p><ul>%2$s</ul><p>%3$s</p>',
-					__( 'These plugins cannot be activated because their requirements form a loop: ' ),
+					__( 'These plugins cannot be activated because their requirements are invalid. ' ),
 					$circular_dependency_lines,
-					__( 'Please contact the plugin developers and make them aware.' )
+					__( 'Please contact the plugin authors for more information.' )
 				),
 				array(
 					'type'           => 'warning',

--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -82,7 +82,7 @@ class WP_Plugin_Dependencies {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	protected static $dependency_filepaths;
 
@@ -93,7 +93,16 @@ class WP_Plugin_Dependencies {
 	 *
 	 * @var array[]
 	 */
-	protected static $circular_dependencies;
+	protected static $circular_dependencies_pairs;
+
+	/**
+	 * An array of circular dependency slugs.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @var string[]
+	 */
+	protected static $circular_dependencies_slugs;
 
 	/**
 	 * Initializes by fetching plugin header and plugin API data,
@@ -222,6 +231,30 @@ class WP_Plugin_Dependencies {
 			$dependency_filepath = self::get_dependency_filepath( $dependency );
 
 			if ( false === $dependency_filepath || is_plugin_inactive( $dependency_filepath ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Determines whether the plugin has a circular dependency.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param string $plugin_file The plugin's filepath, relative to the plugins directory.
+	 * @return bool Whether the plugin has a circular dependency.
+	 */
+	public static function has_circular_dependency( $plugin_file ) {
+		if ( ! is_array( self::$circular_dependencies_slugs ) ) {
+			self::get_circular_dependencies();
+		}
+
+		if ( ! empty( self::$circular_dependencies_slugs ) ) {
+			$slug = self::convert_to_slug( $plugin_file );
+
+			if ( in_array( $slug, self::$circular_dependencies_slugs, true ) ) {
 				return true;
 			}
 		}
@@ -384,7 +417,7 @@ class WP_Plugin_Dependencies {
 				$second_filepath            = $plugin_dirnames[ $circular_dependency[1] ];
 				$circular_dependency_lines .= sprintf(
 					/* translators: 1: First plugin name, 2: Second plugin name. */
-					'<li>' . _x( '%1$s -> %2$s', 'The first plugin requires the second plugin.' ) . '</li>',
+					'<li>' . _x( '%1$s requires %2$s', 'The first plugin requires the second plugin.' ) . '</li>',
 					'<strong>' . esc_html( $plugins[ $first_filepath ]['Name'] ) . '</strong>',
 					'<strong>' . esc_html( $plugins[ $second_filepath ]['Name'] ) . '</strong>'
 				);
@@ -804,11 +837,13 @@ class WP_Plugin_Dependencies {
 	 * @return array[] An array of circular dependency pairings.
 	 */
 	protected static function get_circular_dependencies() {
-		if ( is_array( self::$circular_dependencies ) ) {
-			return self::$circular_dependencies;
+		if ( is_array( self::$circular_dependencies_pairs ) ) {
+			return self::$circular_dependencies_pairs;
 		}
 
-		$circular_dependencies = array();
+		self::$circular_dependencies_slugs = array();
+
+		self::$circular_dependencies_pairs = array();
 		foreach ( self::$dependencies as $dependent => $dependencies ) {
 			/*
 			 * $dependent is in 'a/a.php' format. Dependencies are stored as slugs, i.e. 'a'.
@@ -817,15 +852,13 @@ class WP_Plugin_Dependencies {
 			 */
 			$dependent_slug = self::convert_to_slug( $dependent );
 
-			$circular_dependencies = array_merge(
-				$circular_dependencies,
+			self::$circular_dependencies_pairs = array_merge(
+				self::$circular_dependencies_pairs,
 				self::check_for_circular_dependencies( array( $dependent_slug ), $dependencies )
 			);
 		}
 
-		self::$circular_dependencies = $circular_dependencies;
-
-		return self::$circular_dependencies;
+		return self::$circular_dependencies_pairs;
 	}
 
 	/**
@@ -838,13 +871,14 @@ class WP_Plugin_Dependencies {
 	 * @return array A circular dependency pairing, or an empty array if none exists.
 	 */
 	protected static function check_for_circular_dependencies( $dependents, $dependencies ) {
-		$circular_dependencies = array();
+		$circular_dependencies_pairs = array();
 
 		// Check for a self-dependency.
 		$dependents_location_in_its_own_dependencies = array_intersect( $dependents, $dependencies );
 		if ( ! empty( $dependents_location_in_its_own_dependencies ) ) {
 			foreach ( $dependents_location_in_its_own_dependencies as $self_dependency ) {
-				$circular_dependencies[] = array( $self_dependency, $self_dependency );
+				self::$circular_dependencies_slugs[] = $self_dependency;
+				$circular_dependencies_pairs[]       = array( $self_dependency, $self_dependency );
 
 				// No need to check for itself again.
 				unset( $dependencies[ array_search( $self_dependency, $dependencies, true ) ] );
@@ -872,7 +906,9 @@ class WP_Plugin_Dependencies {
 					);
 
 					if ( false !== $dependent_location_in_dependency_dependencies ) {
-						$circular_dependencies[] = array( $dependent, $dependency );
+						self::$circular_dependencies_slugs[] = $dependent;
+						self::$circular_dependencies_slugs[] = $dependency;
+						$circular_dependencies_pairs[]       = array( $dependent, $dependency );
 
 						// Remove the dependent from its dependency's dependencies.
 						unset( $dependencies_of_the_dependency[ $dependent_location_in_dependency_dependencies ] );
@@ -886,14 +922,14 @@ class WP_Plugin_Dependencies {
 				 *
 				 * Yes, that does make sense.
 				 */
-				$circular_dependencies = array_merge(
-					$circular_dependencies,
+				$circular_dependencies_pairs = array_merge(
+					$circular_dependencies_pairs,
 					self::check_for_circular_dependencies( $dependents, array_unique( $dependencies_of_the_dependency ) )
 				);
 			}
 		}
 
-		return $circular_dependencies;
+		return $circular_dependencies_pairs;
 	}
 
 	/**

--- a/tests/phpunit/tests/admin/plugin-dependencies/base.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/base.php
@@ -23,14 +23,15 @@ abstract class WP_PluginDependencies_UnitTestCase extends WP_UnitTestCase {
 	 * @var array
 	 */
 	protected static $static_properties = array(
-		'plugins'               => null,
-		'plugin_dirnames'       => null,
-		'dependencies'          => null,
-		'dependency_slugs'      => null,
-		'dependent_slugs'       => null,
-		'dependency_api_data'   => null,
-		'dependency_filepaths'  => null,
-		'circular_dependencies' => null,
+		'plugins'                     => null,
+		'plugin_dirnames'             => null,
+		'dependencies'                => null,
+		'dependency_slugs'            => null,
+		'dependent_slugs'             => null,
+		'dependency_api_data'         => null,
+		'dependency_filepaths'        => null,
+		'circular_dependencies_pairs' => null,
+		'circular_dependencies_slugs' => null,
 	);
 
 	/**

--- a/tests/phpunit/tests/admin/plugin-dependencies/hasCircularDependency.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/hasCircularDependency.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Tests for the WP_Plugin_Dependencies::has_circular_dependency() method.
+ *
+ * @package WordPress
+ */
+
+require_once __DIR__ . '/base.php';
+
+/**
+ * @group admin
+ * @group plugins
+ *
+ * @covers WP_Plugin_Dependencies::has_circular_dependency
+ * @covers WP_Plugin_Dependencies::get_circular_dependencies
+ * @covers WP_Plugin_Dependencies::check_for_circular_dependencies
+ */
+class Tests_Admin_WPPluginDependencies_HasCircularDependency extends WP_PluginDependencies_UnitTestCase {
+
+	/**
+	 * Tests that a plugin with a circular dependency will return true.
+	 *
+	 * @dataProvider data_circular_dependencies
+	 *
+	 * @param string  $plugin_to_check The plugin file of the plugin to check.
+	 * @param array[] $plugins         An array of plugins.
+	 */
+	public function test_should_return_true_when_a_plugin_has_circular_dependency( $plugin_to_check, $plugins ) {
+		$this->set_property_value( 'plugins', $plugins );
+		self::$instance::initialize();
+
+		$this->assertTrue( self::$instance::has_circular_dependency( $plugin_to_check ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_circular_dependencies() {
+		return array(
+			'a plugin that depends on itself' => array(
+				'plugin_to_check' => 'dependency/dependency.php',
+				'plugins'         => array(
+					'dependency/dependency.php' => array(
+						'Name'            => 'Dependency 1',
+						'RequiresPlugins' => 'dependency',
+					),
+				),
+			),
+			'two plugins'                     => array(
+				'plugin_to_check' => 'dependency/dependency.php',
+				'plugins'         => array(
+					'dependency/dependency.php'   => array(
+						'Name'            => 'Dependency 1',
+						'RequiresPlugins' => 'dependency2',
+					),
+					'dependency2/dependency2.php' => array(
+						'Name'            => 'Dependency 2',
+						'RequiresPlugins' => 'dependency',
+					),
+				),
+			),
+			'three plugins'                   => array(
+				'plugin_to_check' => 'dependency/dependency.php',
+				'plugins'         => array(
+					'dependency/dependency.php'   => array(
+						'Name'            => 'Dependency 1',
+						'RequiresPlugins' => 'dependency2',
+					),
+					'dependency2/dependency2.php' => array(
+						'Name'            => 'Dependency 2',
+						'RequiresPlugins' => 'dependency3',
+					),
+					'dependency3/dependency3.php' => array(
+						'Name'            => 'Dependency 3',
+						'RequiresPlugins' => 'dependency',
+					),
+				),
+			),
+			'four plugins'                    => array(
+				'plugin_to_check' => 'dependency/dependency.php',
+				'plugins'         => array(
+					'dependency/dependency.php'   => array(
+						'Name'            => 'Dependency 1',
+						'RequiresPlugins' => 'dependency4',
+					),
+					'dependency2/dependency2.php' => array(
+						'Name'            => 'Dependency 2',
+						'RequiresPlugins' => 'dependency3',
+					),
+					'dependency3/dependency3.php' => array(
+						'Name'            => 'Dependency 3',
+						'RequiresPlugins' => 'dependency',
+					),
+					'dependency4/dependency4.php' => array(
+						'Name'            => 'Dependency 4',
+						'RequiresPlugins' => 'dependency2',
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Tests that a plugin with no circular dependencies will return false.
+	 */
+	public function test_should_return_false_when_a_plugin_has_no_circular_dependency() {
+		$this->set_property_value(
+			'plugins',
+			array(
+				'dependency/dependency.php' => array(
+					'Name'            => 'Dependency 1',
+					'RequiresPlugins' => 'dependency2',
+				),
+			),
+		);
+
+		$this->assertFalse( self::$instance::has_circular_dependency( 'dependent/dependent.php' ) );
+	}
+}


### PR DESCRIPTION
Circular dependencies were not being properly detected. Additionally, circular dependencies could not be deleted.

This PR fixes both of these and includes tests.